### PR TITLE
Update key file name

### DIFF
--- a/src/ClrPro.AzureFX.LocalCredentialBridge/Controllers/TokensBridgetController.cs
+++ b/src/ClrPro.AzureFX.LocalCredentialBridge/Controllers/TokensBridgetController.cs
@@ -70,7 +70,7 @@ public class TokensBridgetController : ControllerBase
             var authHeader = Request.Headers.Authorization;
             if (string.IsNullOrWhiteSpace(authHeader))
             {
-                var fileName = Guid.NewGuid().ToString();
+                var fileName = $"{Guid.NewGuid().ToString()}.key";
                 var localFileName = Path.Combine(localPath, fileName);
                 var remoteFileName = Path.Combine(options.RemoteTokensPath!, fileName);
 


### PR DESCRIPTION
Azure.Identity updated to validate the key path. Credential bridge saves a new guid as the file path, which did not pass the new validation.

https://github.com/Azure/azure-sdk-for-net/pull/44483/files#diff-03a57cc8541a8a2066317dcaa35be537ba806d60fc4d7e1272573de98e4b7757